### PR TITLE
Role fix

### DIFF
--- a/app/models/spree/volume_price.rb
+++ b/app/models/spree/volume_price.rb
@@ -27,7 +27,7 @@ class Spree::VolumePrice < ActiveRecord::Base
       )
     ).
     where(role_id: roles).
-    order(position: :asc)
+    order(position: :asc, amount: :asc)
   end
 
   def include?(quantity)

--- a/app/models/spree/volume_price.rb
+++ b/app/models/spree/volume_price.rb
@@ -15,11 +15,19 @@ class Spree::VolumePrice < ActiveRecord::Base
   validate :range_format
 
   def self.for_variant(variant, user: nil)
+    roles = [nil]
+    if user
+      roles << user.resolve_role.try!(:id)
+    end
+
     where(
-      (arel_table[:variant_id].eq(variant.id)
-        .or(arel_table[:volume_price_model_id].in(variant.volume_price_model_ids)))
-        .and(arel_table[:role_id].eq(user.try!(:resolve_role)))
-    ).order(position: :asc)
+      arel_table[:variant_id].eq(variant.id).
+      or(
+        arel_table[:volume_price_model_id].in(variant.volume_price_model_ids)
+      )
+    ).
+    where(role_id: roles).
+    order(position: :asc)
   end
 
   def include?(quantity)

--- a/lib/solidus_volume_pricing/version.rb
+++ b/lib/solidus_volume_pricing/version.rb
@@ -9,7 +9,7 @@ module SolidusVolumePricing
 
   module VERSION
     MAJOR = 0
-    MINOR = 2
+    MINOR = 3
     TINY  = 0
     PRE   = nil
 

--- a/spec/models/spree/volume_price_spec.rb
+++ b/spec/models/spree/volume_price_spec.rb
@@ -42,21 +42,29 @@ RSpec.describe Spree::VolumePrice, type: :model do
 
       context 'whose role matches' do
         before do
-          expect_any_instance_of(Spree::LegacyUser).to receive(:has_spree_role?) { true }
+          user.spree_roles = [role]
         end
 
-        it 'returns all volume prices for given variant that are related to role of user' do
-          expect(subject).to eq(volume_prices_for_user_role)
+        it 'returns role specific volume prices' do
+          expect(subject).to include(*volume_prices_for_user_role)
+        end
+
+        it 'returns non-role specific volume prices' do
+          expect(subject).to include(*volume_prices)
         end
       end
 
       context 'whose role does not match' do
         before do
-          expect_any_instance_of(Spree::LegacyUser).to receive(:has_spree_role?) { false }
+          user.spree_roles = []
         end
 
-        it 'returns all volume prices for given variant that are not related to any particular role' do
-          expect(subject).to eq(volume_prices)
+        it 'does not include role specific volume prices' do
+          expect(subject).to_not include(*volume_prices_for_user_role)
+        end
+
+        it 'returns non-role specific volume prices' do
+          expect(subject).to include(*volume_prices)
         end
       end
     end


### PR DESCRIPTION
Volume prices by default are not associated with any role. Users however
in old systems are associated with the "User" role by default.

This means that when a user is logged in, they will never get prices
that don't require a role.

Instead, if a user is logged in, they should see prices that are non
role specific, and prices that are.

Also bumps the gem version. Will need a push to rubygems