### PR TITLE
V2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ env:
     - SOLIDUS_BRANCH=v1.3 DB=postgresql
     - SOLIDUS_BRANCH=v1.4 DB=mysql
     - SOLIDUS_BRANCH=v1.4 DB=postgresql
+    - SOLIDUS_BRANCH=v2.0 DB=mysql
+    - SOLIDUS_BRANCH=v2.0 DB=postgresql
+    - SOLIDUS_BRANCH=v2.1 DB=mysql
+    - SOLIDUS_BRANCH=v2.1 DB=postgresql
 before_install:
   - rvm use @global
   - gem uninstall bundler -x

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Spree::Core::Engine.add_routes do
+Spree::Core::Engine.routes.draw do
   namespace :admin do
     resources :products do
       resources :variants do

--- a/lib/solidus_volume_pricing.rb
+++ b/lib/solidus_volume_pricing.rb
@@ -1,3 +1,4 @@
+require 'active_support/deprecation'
 require 'sass/rails'
 require 'deface'
 require 'solidus_core'

--- a/solidus_volume_pricing.gemspec
+++ b/solidus_volume_pricing.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency 'solidus_core', '~> 1.3'
+  s.add_runtime_dependency 'solidus_core', '>= 1.3'
   s.add_runtime_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency 'sqlite3', '>= 1.3.10'


### PR DESCRIPTION
Updates this gem for Solidus 2.1 / Rails 5 compatibility.

All tests pass and everything seems to be in working order. The only necessary change was replacing "add_routes" - removed in Rails 5 - with "routes.draw" in config/routes.rb.

Unless I'm missing any obvious issues, this should solve #8 