### PR TITLE
Remove deprecated icon option from button

### DIFF
--- a/app/views/spree/admin/variants/volume_prices.html.erb
+++ b/app/views/spree/admin/variants/volume_prices.html.erb
@@ -4,7 +4,7 @@
 <% content_for :page_actions do %>
   <span id="new_add_volume_price" data-hook>
     <%= button_link_to Spree.t(:add_volume_price), 'javascript:;', {
-      icon: 'add', :'data-target' => 'tbody#volume_prices', class: 'btn-success spree_add_fields', id: 'add_volume_price'} %>
+      :'data-target' => 'tbody#volume_prices', class: 'btn-success spree_add_fields', id: 'add_volume_price'} %>
   </span>
 <% end %>
 


### PR DESCRIPTION
This removes a deprecated icon option from a button on the volume prices template.