### PR TITLE
Fix factory girl dependency for Solidus < 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ env:
     - SOLIDUS_BRANCH=master DB=mysql
 before_install:
   - rvm use @global
+  - gem install bundler --version=1.13.7
   - bundler --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.3.3
+  - 2.5.1
 sudo: false
 cache: bundler
 only: master
@@ -22,6 +22,4 @@ env:
     - SOLIDUS_BRANCH=master DB=mysql
 before_install:
   - rvm use @global
-  - gem uninstall bundler -x
-  - gem install bundler --version=1.13.7
   - bundler --version

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'v1.3')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus", github: "solidusio/solidus", branch: branch
 
 case ENV['DB']

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,12 @@ when 'postgresql'
   gem 'pg'
 end
 
+group :test do
+  if branch < "v2.5"
+    gem 'factory_bot', '4.10.0'
+  else
+    gem 'factory_bot', '> 4.10.0'
+  end
+end
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,8 @@ source 'https://rubygems.org'
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem "solidus", github: "solidusio/solidus", branch: branch
 
-case ENV['DB']
-when 'mysql'
-  gem 'mysql2'
-when 'postgresql'
-  gem 'pg'
-end
+gem 'pg'
+gem 'mysql'
 
 group :test do
   if branch < "v2.5"


### PR DESCRIPTION
We need to load a factory_bot version that has factory_girl in it
to support Solidus versions < 2.5

This change also includes conditional logic for the database
interface gems.