### PR TITLE
Switch to sassc/rails

### DIFF
--- a/lib/solidus_volume_pricing.rb
+++ b/lib/solidus_volume_pricing.rb
@@ -1,5 +1,5 @@
 require 'active_support/deprecation'
-require 'sass/rails'
+require 'sassc/rails'
 require 'deface'
 require 'solidus_core'
 require 'solidus_volume_pricing/engine'

--- a/solidus_volume_pricing.gemspec
+++ b/solidus_volume_pricing.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'poltergeist', '~> 1.6'
   s.add_development_dependency 'database_cleaner', '~> 1.4'
   s.add_development_dependency 'coffee-rails', '~> 4.0'
-  s.add_development_dependency 'sass-rails', '~> 5.0'
+  s.add_development_dependency 'sassc-rails'
   s.add_development_dependency 'rubocop', '>= 0.24.1'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'solidus_support'


### PR DESCRIPTION
Ruby Sass EOL was 26 Mar 2019:
https://github.com/rails/sass-rails/issues/420

This PR updates the extension to use sassc instead.