### PR TITLE
Replace I18n.t with t in views

### DIFF
--- a/app/views/spree/admin/shared/_vp_product_tab.html.erb
+++ b/app/views/spree/admin/shared/_vp_product_tab.html.erb
@@ -1,3 +1,3 @@
-<%= content_tag :li, class: ('active' if current == I18n.t('spree.volume_pricing')) do %>
-  <%= link_to I18n.t('spree.volume_pricing'), volume_prices_admin_product_variant_url(@product, @product.master) %>
+<%= content_tag :li, class: ('active' if current == t('spree.volume_pricing')) do %>
+  <%= link_to t('spree.volume_pricing'), volume_prices_admin_product_variant_url(@product, @product.master) %>
 <% end %>

--- a/app/views/spree/admin/variants/_edit_fields.html.erb
+++ b/app/views/spree/admin/variants/_edit_fields.html.erb
@@ -1,5 +1,5 @@
 <fieldset>
-  <legend><%= I18n.t('spree.volume_prices') %></legend>
+  <legend><%= t('spree.volume_prices') %></legend>
 
   <%= render 'spree/admin/volume_price_models/select', f: f %>
   <%= render 'spree/admin/volume_prices/table', f: f %>

--- a/app/views/spree/admin/variants/volume_prices.html.erb
+++ b/app/views/spree/admin/variants/volume_prices.html.erb
@@ -1,8 +1,8 @@
-<%= render 'spree/admin/shared/product_tabs', current: I18n.t('spree.volume_pricing') %>
+<%= render 'spree/admin/shared/product_tabs', current: t('spree.volume_pricing') %>
 <%= render 'spree/shared/error_messages', target: @variant %>
 
 <fieldset>
-  <legend><%= I18n.t('spree.volume_prices') %></legend>
+  <legend><%= t('spree.volume_prices') %></legend>
 
   <%= form_for(@variant, url: admin_product_variant_path(@product, @variant), html: { method: :put }) do |f| %>
     <%= render 'spree/admin/volume_price_models/select', f: f %>

--- a/app/views/spree/admin/volume_price_models/_form.html.erb
+++ b/app/views/spree/admin/volume_price_models/_form.html.erb
@@ -1,12 +1,12 @@
 <div data-hook="admin_inside_volume_price_model_form" class="form-group">
   <%= f.field_container :name, class: ['form-group'] do %>
-    <%= f.label :name, I18n.t('spree.name') %> <span class="required">*</span>
+    <%= f.label :name, t('spree.name') %> <span class="required">*</span>
     <%= error_message_on :volume_price_model, :name, :class => 'error-message' %>
     <%= text_field :volume_price_model, :name, :class => 'form-control' %>
   <% end %>
 
   <fieldset>
-    <legend><%= I18n.t('spree.volume_prices') %></legend>
+    <legend><%= t('spree.volume_prices') %></legend>
 
     <%= render 'spree/admin/volume_prices/table', f: f %>
   </fieldset>

--- a/app/views/spree/admin/volume_price_models/_list.html.erb
+++ b/app/views/spree/admin/volume_price_models/_list.html.erb
@@ -2,7 +2,7 @@
   <thead>
     <tr data-hook="volume_price_models_header">
       <th class="no-border"></th>
-      <th><%= I18n.t('spree.name') %></th>
+      <th><%= t('spree.name') %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/app/views/spree/admin/volume_price_models/_select.html.erb
+++ b/app/views/spree/admin/volume_price_models/_select.html.erb
@@ -1,11 +1,11 @@
 <div class="row">
   <div class="col-4">
     <%= f.field_container :volume_price_model, class: ['form-group'] do %>
-      <%= f.label :volume_price_model_id, I18n.t('spree.volume_price_model') %>
+      <%= f.label :volume_price_model_id, t('spree.volume_price_model') %>
       <%= f.collection_select :volume_price_model_ids,
         Spree::VolumePriceModel.all, :id, :name,
         {
-          include_blank: I18n.t('spree.match_choices.none')
+          include_blank: t('spree.match_choices.none')
         },
         {
           class: 'custom-select fullwidth',

--- a/app/views/spree/admin/volume_price_models/edit.html.erb
+++ b/app/views/spree/admin/volume_price_models/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= I18n.t('spree.volume_price_model_edit') %>
+  <%= t('spree.volume_price_model_edit') %>
 <% end %>
 
 <% admin_breadcrumb(link_to plural_resource_name(Spree::VolumePriceModel), admin_volume_price_models_path) %>

--- a/app/views/spree/admin/volume_price_models/index.html.erb
+++ b/app/views/spree/admin/volume_price_models/index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-  <%= link_to I18n.t('spree.new_volume_price_model'), new_object_url, class: "btn btn-primary", id: 'admin_new_volume_price_model_link' %>
+  <%= link_to t('spree.new_volume_price_model'), new_object_url, class: "btn btn-primary", id: 'admin_new_volume_price_model_link' %>
 <% end %>
 
 <% if @volume_price_models.any? %>
@@ -12,9 +12,9 @@
   </div>
 <% else %>
   <div class="no-objects-found">
-    <%= I18n.t('spree.no_resource_found', resource: plural_resource_name(Spree::VolumePriceModel)) %>,
+    <%= t('spree.no_resource_found', resource: plural_resource_name(Spree::VolumePriceModel)) %>,
     <% if can? :create, Spree::VolumePriceModel %>
-      <%= link_to I18n.t('spree.create_one'), new_object_url %>
+      <%= link_to t('spree.create_one'), new_object_url %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/spree/admin/volume_price_models/new.html.erb
+++ b/app/views/spree/admin/volume_price_models/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= I18n.t('spree.new_volume_price_model') %>
+  <%= t('spree.new_volume_price_model') %>
 <% end %>
 
 <% admin_breadcrumb(link_to plural_resource_name(Spree::VolumePriceModel), admin_volume_price_models_path) %>

--- a/app/views/spree/admin/volume_prices/_table.html.erb
+++ b/app/views/spree/admin/volume_prices/_table.html.erb
@@ -1,12 +1,12 @@
 <table class="table">
   <thead>
     <tr>
-      <th><%= I18n.t('spree.name') %></th>
-      <th><%= I18n.t('spree.discount_type') %></th>
-      <th><%= I18n.t('spree.range') %></th>
-      <th><%= I18n.t('spree.amount') %></th>
-      <th><%= I18n.t('spree.position') %></th>
-      <th><%= I18n.t('spree.role') %></th>
+      <th><%= t('spree.name') %></th>
+      <th><%= t('spree.discount_type') %></th>
+      <th><%= t('spree.range') %></th>
+      <th><%= t('spree.amount') %></th>
+      <th><%= t('spree.position') %></th>
+      <th><%= t('spree.role') %></th>
       <th class="actions"></th>
     </tr>
   </thead>

--- a/app/views/spree/admin/volume_prices/_volume_price_fields.html.erb
+++ b/app/views/spree/admin/volume_prices/_volume_price_fields.html.erb
@@ -6,9 +6,9 @@
   <td>
     <%= error_message_on(f.object, :discount_type) %>
     <%= f.select :discount_type, [
-        [I18n.t('spree.total_price'), 'price'],
-        [I18n.t('spree.percent_discount'), 'percent'],
-        [I18n.t('spree.price_discount'), 'dollar']
+        [t('spree.total_price'), 'price'],
+        [t('spree.percent_discount'), 'percent'],
+        [t('spree.price_discount'), 'dollar']
       ], { include_blank: true }, class: 'custom-select' %>
   </td>
   <td>
@@ -25,9 +25,9 @@
   </td>
   <td>
     <%= error_message_on(f.object, :role_id) %>
-    <%= f.collection_select(:role_id, Spree::Role.all, :id, :name, { include_blank: I18n.t('spree.match_choices.none') }, { class: 'custom-select' }) %>
+    <%= f.collection_select(:role_id, Spree::Role.all, :id, :name, { include_blank: t('spree.match_choices.none') }, { class: 'custom-select' }) %>
   </td>
   <td class="actions">
-    <%= link_to_remove_fields I18n.t('spree.remove'), f, no_text: true %>
+    <%= link_to_remove_fields t('spree.remove'), f, no_text: true %>
   </td>
 </tr>

--- a/app/views/spree/products/_volume_pricing.html.erb
+++ b/app/views/spree/products/_volume_pricing.html.erb
@@ -1,7 +1,7 @@
 <% display_percent ||= false %>
 <% if product.price > 0 and product.master.volume_prices.present? %>
   <div id="bulk-discount">
-    <h6><%= I18n.t('spree.bulk_discount') %></h6>
+    <h6><%= t('spree.bulk_discount') %></h6>
     <table class="table">
       <% product.master.volume_prices.each do |v| %>
         <%= content_tag(:tr) do %>


### PR DESCRIPTION
Closes #22.

The t helper provides more features than I18n.t, so we ought to use it in views.