### PR TITLE
Configure autoloader to ignore decorators

### DIFF
--- a/lib/solidus_volume_pricing/engine.rb
+++ b/lib/solidus_volume_pricing/engine.rb
@@ -19,6 +19,7 @@ module SolidusVolumePricing
     def self.activate
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
+        Rails.autoloaders.main.ignore(c) if Rails.autoloaders.zeitwerk_enabled?
       end
       ::Spree::BackendConfiguration::CONFIGURATION_TABS << :volume_price_models
     end


### PR DESCRIPTION
This configures the autoloader to ignore decorators since they are already explicitly required by the engine. This is necessary for `bin/rails zeitwerk:check` to pass on projects using this gem.

Without this change, the check fails because the decorators are not in the expected namespace:

```
expected file /Users/matt/.rvm/gems/ruby-2.7.5/gems/solidus_volume_pricing-1.0.0/app/decorators/models/solidus_volume_pricing/spree/variant_decorator.rb to define constant Models::SolidusVolumePricing::Spree::VariantDecorator
```