### PR TITLE
Stop loading decorators twice

### DIFF
--- a/lib/solidus_volume_pricing/engine.rb
+++ b/lib/solidus_volume_pricing/engine.rb
@@ -18,14 +18,8 @@ module SolidusVolumePricing
     end
 
     def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')).sort.each do |c|
-        Rails.configuration.cache_classes ? require(c) : load(c)
-        Rails.autoloaders.main.ignore(c) if Rails.autoloaders.zeitwerk_enabled?
-      end
       ::Spree::BackendConfiguration::CONFIGURATION_TABS << :volume_price_models
     end
-
-    config.to_prepare(&method(:activate).to_proc)
 
     # use rspec for tests
     config.generators do |g|


### PR DESCRIPTION
[solidus_support](https://github.com/solidusio/solidus_support) is already loading this gem's decorators. This change also fixes several warnings about duplicate constants during Rails initialization. For example:

```
~/.rvm/gems/ruby-3.2.2/gems/activerecord-7.0.7.2/lib/active_record/associations.rb:1978: warning: already initialized constant Spree::Variant::HABTM_VolumePriceModels
~/.rvm/gems/ruby-3.2.2/gems/activerecord-7.0.7.2/lib/active_record/associations.rb:1978: warning: previous definition of HABTM_VolumePriceModels was here
```