### PR TITLE
Lock sqlite3 to specific version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ when 'mysql'
 when 'postgresql'
   gem 'pg'
 else
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4'
 end
 
 # While we still support Ruby < 3 we need to workaround a limitation in


### PR DESCRIPTION
This should fix the CircleCI build which has been breaking with the following error:

```
rails aborted!
LoadError: Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-x86_64-linux-gnu. Make sure all dependencies are added to Gemfile.
/home/circleci/project/spec/dummy/app/controllers/application_controller.rb:1:in `<top (required)>'
/home/circleci/project/spec/dummy/config/environment.rb:5:in `<top (required)>'

Caused by:
Gem::LoadError: can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.1-x86_64-linux-gnu. Make sure all dependencies are added to Gemfile.
/home/circleci/project/spec/dummy/app/controllers/application_controller.rb:1:in `<top (required)>'
/home/circleci/project/spec/dummy/config/environment.rb:5:in `<top (required)>'
Tasks: TOP => db:environment:set => db:load_config => environment
(See full trace by running task with --trace)

Exited with code exit status 1
```