### PR TITLE
Fix deprecated `*_TABS` constant

### DIFF
--- a/lib/solidus_volume_pricing/engine.rb
+++ b/lib/solidus_volume_pricing/engine.rb
@@ -17,8 +17,25 @@ module SolidusVolumePricing
       end
     end
 
-    def self.activate
-      ::Spree::BackendConfiguration::CONFIGURATION_TABS << :volume_price_models
+    if SolidusSupport.backend_available?
+      initializer 'solidus_volume_pricing.admin_menu_item', after: 'solidus_volume_pricing.preferences' do
+        Spree::Backend::Config.configure do |config|
+          settings_menu_item = config.menu_items.detect { |mi| mi.label == :settings }
+
+          # The API of the MenuItem class changes in Solidus 4.2.0
+          if settings_menu_item.respond_to?(:children)
+            settings_menu_item.children.concat([
+              Spree::BackendConfiguration::MenuItem.new(
+                label: :volume_price_models,
+                url: :admin_volume_price_models_path,
+                match_path: %r{admin/volume_price_models}
+              )
+            ])
+          else
+            ::Spree::BackendConfiguration::CONFIGURATION_TABS << :volume_price_models
+          end
+        end
+      end
     end
 
     # use rspec for tests


### PR DESCRIPTION
For Solidus 4.2+, we should be using the `MenuItem` class instead of appending to the deprecated `*_TABS` constant. This fixes the deprecation warning on app boot. See https://github.com/solidusio/solidus/pull/5309

```
DEPRECATION WARNING: Spree::BackendConfiguration::*_TABS is deprecated. Please use Spree::BackendConfiguration::MenuItem(match_path:) instead.
```