### PR TITLE
Add support for volume pricing based on pricing bands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
   lint-code:
     executor:
       name: solidusio_extensions/sqlite
-      ruby_version: "3.0"
+      ruby_version: "3.1"
     steps:
       - solidusio_extensions/lint-code
 
@@ -43,15 +43,15 @@ workflows:
       - run-specs:
           name: &name "run-specs-solidus-<< matrix.solidus >>-ruby-<< matrix.ruby >>-db-<< matrix.db >>"
           matrix:
-            parameters: { solidus: ["main"], ruby: ["3.2"], db: ["postgres"] }
+            parameters: { solidus: ["main"], ruby: ["3.3"], db: ["postgres"] }
       - run-specs:
           name: *name
           matrix:
-            parameters: { solidus: ["current"], ruby: ["3.1"], db: ["mysql"] }
+            parameters: { solidus: ["current"], ruby: ["3.2"], db: ["mysql"] }
       - run-specs:
           name: *name
           matrix:
-            parameters: { solidus: ["older"], ruby: ["3.0"], db: ["sqlite"] }
+            parameters: { solidus: ["older"], ruby: ["3.1"], db: ["sqlite"] }
       - lint-code
 
   "Weekly run specs against main":

--- a/app/decorators/models/solidus_volume_pricing/spree/line_item_decorator.rb
+++ b/app/decorators/models/solidus_volume_pricing/spree/line_item_decorator.rb
@@ -6,7 +6,10 @@ module SolidusVolumePricing
       def set_pricing_attributes
         if quantity_changed?
           options = SolidusVolumePricing::PricingOptions.from_line_item(self)
-          self.money_price = SolidusVolumePricing::Pricer.new(variant).price_for(options)
+          pricer = SolidusVolumePricing::Pricer.new(variant)
+          if pricer.volume_pricing?(options)
+            self.money_price = pricer.price_for(options)
+          end
         end
 
         super

--- a/app/models/solidus_volume_pricing/pricer.rb
+++ b/app/models/solidus_volume_pricing/pricer.rb
@@ -10,17 +10,22 @@ module SolidusVolumePricing
 
     def price_for(pricing_options)
       extract_options(pricing_options)
-      ::Spree::Money.new(computed_price)
+      ::Spree::Money.new(computed_price(pricing_options.quantity))
     end
 
     def earning_amount(pricing_options)
       extract_options(pricing_options)
-      ::Spree::Money.new(computed_earning)
+      ::Spree::Money.new(computed_earning(pricing_options.quantity))
     end
 
     def earning_percent(pricing_options)
       extract_options(pricing_options)
-      computed_earning_percent.round
+      computed_earning_percent(pricing_options.quantity).round
+    end
+
+    def volume_pricing?(pricing_options)
+      extract_options(pricing_options)
+      get_volume_price_for(pricing_options.quantity).present?
     end
 
     private
@@ -46,50 +51,48 @@ module SolidusVolumePricing
       ::Spree::VolumePrice.for_variant(variant, user: user)
     end
 
-    def volume_price
+    def get_volume_price_for(quantity)
       volume_prices.detect do |volume_price|
         volume_price.include?(quantity)
       end
     end
 
-    def computed_price
-      case volume_price&.discount_type
-      when 'price'
-        volume_price.amount
-      when 'dollar'
-        variant.price - volume_price.amount
-      when 'percent'
-        variant.price * (1 - volume_price.amount)
+    def computed_price(quantity)
+      volume_price = get_volume_price_for(quantity)
+      band_price = case volume_price&.discount_type
+                   when /price/
+                     volume_price.amount
+                   when /dollar/
+                     variant.price - volume_price.amount
+                   when /percent/
+                     variant.price * (1 - volume_price.amount)
+                   else
+                     variant.price
+                   end
+
+      if volume_price&.discount_type&.starts_with?('banded_')
+        range_start = volume_price.begin
+        amount = quantity - range_start + 1
+        band_total = amount * band_price
+        if range_start > 1
+          band_total += computed_price(range_start - 1) * (range_start - 1)
+        end
+        band_total / quantity
       else
-        variant.price
+        band_price
       end
     end
 
-    def computed_earning
-      case volume_price&.discount_type
-      when 'price'
-        variant.price - volume_price.amount
-      when 'dollar'
-        volume_price.amount
-      when 'percent'
-        variant.price - (variant.price * (1 - volume_price.amount))
-      else
-        0
-      end
+    def computed_earning(quantity)
+      total_with_discount = computed_price(quantity) * quantity
+      total_without_discount = variant.price * quantity
+      (total_without_discount - total_with_discount) / quantity
     end
 
-    def computed_earning_percent
-      case volume_price&.discount_type
-      when 'price'
-        diff = variant.price - volume_price.amount
-        diff * 100 / variant.price
-      when 'dollar'
-        volume_price.amount * 100 / variant.price
-      when 'percent'
-        volume_price.amount * 100
-      else
-        0
-      end
+    def computed_earning_percent(quantity)
+      total_with_discount = computed_price(quantity) * quantity
+      total_without_discount = variant.price * quantity
+      100 - (total_with_discount * 100 / total_without_discount)
     end
   end
 end

--- a/app/models/spree/volume_price.rb
+++ b/app/models/spree/volume_price.rb
@@ -11,7 +11,7 @@ module Spree
     validates :discount_type,
       presence: true,
       inclusion: {
-        in: %w(price dollar percent)
+        in: %w(price dollar percent banded_price banded_dollar banded_percent)
       }
 
     validate :range_format
@@ -31,6 +31,7 @@ module Spree
     end
 
     delegate :include?, to: :range_from_string
+    delegate :begin, to: :range_from_string
 
     def display_range
       range.gsub(/\.+/, "-").gsub(/\(|\)/, '')

--- a/app/views/spree/admin/volume_prices/_volume_price_fields.html.erb
+++ b/app/views/spree/admin/volume_prices/_volume_price_fields.html.erb
@@ -8,7 +8,10 @@
     <%= f.select :discount_type, [
         [t('spree.total_price'), 'price'],
         [t('spree.percent_discount'), 'percent'],
-        [t('spree.price_discount'), 'dollar']
+        [t('spree.price_discount'), 'dollar'],
+        [t('spree.banded_total_price'), 'banded_price'],
+        [t('spree.banded_percent_discount'), 'banded_percent'],
+        [t('spree.banded_price_discount'), 'banded_dollar']
       ], { include_blank: true }, class: 'custom-select' %>
   </td>
   <td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,10 +11,13 @@ en:
     new_volume_price_model: New Volume Price Model
     volume_price_model_edit: Edit Volume Price Model
     volume_pricing: Volume Pricing
-    price_discount: Price Discount
-    percent_discount: Percent Discount
     bulk_discount: Bulk Discount
-    total_price: Total price
+    price_discount: Price Discount (All items)
+    percent_discount: Percent Discount (All items)
+    total_price: Total price (All items)
+    banded_price_discount: Price Discount (Banded)
+    banded_percent_discount: Percent Discount (Banded)
+    banded_total_price: Total price (Banded)
     admin:
       tab:
         volume_price_models: Volume Price Models

--- a/spec/features/manage_volume_price_models_feature_spec.rb
+++ b/spec/features/manage_volume_price_models_feature_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Managing volume price models', type: :system do
     fill_in 'Name', with: 'Discount'
     within '#volume_prices' do
       fill_in 'volume_price_model_volume_prices_attributes_0_name', with: '5 pieces discount'
-      select 'Total price', from: 'volume_price_model_volume_prices_attributes_0_discount_type'
+      select 'Total price (All items)', from: 'volume_price_model_volume_prices_attributes_0_discount_type'
       fill_in 'volume_price_model_volume_prices_attributes_0_range', with: '1..5'
       fill_in 'volume_price_model_volume_prices_attributes_0_amount', with: '1'
     end

--- a/spec/features/manage_volume_prices_feature_spec.rb
+++ b/spec/features/manage_volume_prices_feature_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Managing volume prices' do
     expect(page).to have_content('Volume Prices')
 
     fill_in 'variant_volume_prices_attributes_0_name', with: '5 pieces discount'
-    select 'Total price', from: 'variant_volume_prices_attributes_0_discount_type'
+    select 'Total price (All items)', from: 'variant_volume_prices_attributes_0_discount_type'
     fill_in 'variant_volume_prices_attributes_0_range', with: '1..5'
     fill_in 'variant_volume_prices_attributes_0_amount', with: '1'
     click_on 'Update'

--- a/spec/models/spree/volume_price_spec.rb
+++ b/spec/models/spree/volume_price_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe Spree::VolumePrice, type: :model do
   it { is_expected.to validate_presence_of(:discount_type) }
   it { is_expected.to validate_presence_of(:amount) }
 
-  it { is_expected.to validate_inclusion_of(:discount_type).in_array(%w[price dollar percent]) }
+  it {
+    expect(subject).to validate_inclusion_of(:discount_type).in_array(%w[price dollar percent banded_price banded_dollar
+                                                                         banded_percent])
+  }
 
   describe '.for_variant' do
     subject { described_class.for_variant(variant, user: user) }


### PR DESCRIPTION
This allows discounts to be set on the actual quantities which end up in the specific range, with the rest calculated on the full price (or the respective discount set up for that band)

Main caveat is that first a per-item price is calculated and then backfilled for the total, which due to rounding down to cents which could be lower than what you expect. If quantities above 100 are expected it is important to set up the pricing to cater for this difference. This caveat also applied to percent based discounts as well even before this change however, this has been added to the README to make it clear.