### PR TITLE
Add Solidus 4.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
         rails-version:
           - "7.1"
           - "7.2"
+          - "8.0"
         ruby-version:
           - "3.1"
           - "3.4"
@@ -32,6 +33,7 @@ jobs:
           - "v4.2"
           - "v4.3"
           - "v4.4"
+          - "v4.5"
           - "main"
         database:
           - "postgresql"
@@ -48,6 +50,14 @@ jobs:
             solidus-branch: "v4.2"
           - rails-version: "7.1"
             solidus-branch: "v4.1"
+          - rails-version: "8.0"
+            solidus-branch: "v4.2"
+          - rails-version: "8.0"
+            solidus-branch: "v4.3"
+          - rails-version: "8.0"
+            solidus-branch: "v4.4"
+          - rails-version: "8.0"
+            ruby-version: "3.1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,18 +20,15 @@ jobs:
     name: Solidus ${{ matrix.solidus-branch }}, Rails ${{ matrix.rails-version }} and Ruby ${{ matrix.ruby-version }} on ${{ matrix.database }}
     runs-on: ubuntu-24.04
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         rails-version:
-          - "7.1"
           - "7.2"
           - "8.0"
         ruby-version:
           - "3.1"
           - "3.4"
         solidus-branch:
-          - "v4.2"
-          - "v4.3"
           - "v4.4"
           - "v4.5"
           - "main"
@@ -40,20 +37,6 @@ jobs:
           - "mysql"
           - "sqlite"
         exclude:
-          - rails-version: "7.2"
-            solidus-branch: "v4.3"
-          - rails-version: "7.2"
-            solidus-branch: "v4.2"
-          - rails-version: "7.2"
-            solidus-branch: "v4.1"
-          - rails-version: "7.1"
-            solidus-branch: "v4.2"
-          - rails-version: "7.1"
-            solidus-branch: "v4.1"
-          - rails-version: "8.0"
-            solidus-branch: "v4.2"
-          - rails-version: "8.0"
-            solidus-branch: "v4.3"
           - rails-version: "8.0"
             solidus-branch: "v4.4"
           - rails-version: "8.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         solidus-branch:
           - "v4.4"
           - "v4.5"
-          - "main"
+          - "v4.6"
         database:
           - "postgresql"
           - "mysql"

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,13 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-branch = ENV.fetch("SOLIDUS_BRANCH", "main")
+branch = ENV.fetch("SOLIDUS_BRANCH", "v4.6")
 gem "solidus", github: "solidusio/solidus", branch: branch
 
 # The solidus_frontend gem has been pulled out since v3.2
 gem "solidus_frontend"
 
-rails_requirement_string = ENV.fetch("RAILS_VERSION", "~> 7.0")
+rails_requirement_string = ENV.fetch("RAILS_VERSION", "~> 8.0")
 gem "rails", rails_requirement_string
 
 # Provides basic authentication functionality for testing parts of your engine

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+gemspec
+
 branch = ENV.fetch("SOLIDUS_BRANCH", "v4.6")
 gem "solidus", github: "solidusio/solidus", branch: branch
 
@@ -31,8 +33,6 @@ end
 # the 'async' gem that relies on the latest ruby, since RubyGems doesn't
 # resolve gems based on the required ruby version.
 gem "async", "< 3" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3")
-
-gemspec
 
 # Use a local Gemfile to include development dependencies that might not be
 # relevant for the project or for other contributors, e.g. pry-byebug.

--- a/Gemfile
+++ b/Gemfile
@@ -29,11 +29,6 @@ else
   gem "sqlite3", sqlite_version
 end
 
-# While we still support Ruby < 3 we need to workaround a limitation in
-# the 'async' gem that relies on the latest ruby, since RubyGems doesn't
-# resolve gems based on the required ruby version.
-gem "async", "< 3" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3")
-
 # Use a local Gemfile to include development dependencies that might not be
 # relevant for the project or for other contributors, e.g. pry-byebug.
 #

--- a/app/patches/models/solidus_volume_pricing/spree_line_item_patch.rb
+++ b/app/patches/models/solidus_volume_pricing/spree_line_item_patch.rb
@@ -2,13 +2,15 @@
 
 module SolidusVolumePricing
   module SpreeLineItemPatch
-    def set_pricing_attributes
-      if quantity_changed?
-        options = SolidusVolumePricing::PricingOptions.from_line_item(self)
-        self.money_price = SolidusVolumePricing::Pricer.new(variant).price_for(options)
-      end
+    def self.prepended(base)
+      base.before_validation :set_volume_pricing_attributes, if: :quantity_changed?
+    end
 
-      super
+    private
+
+    def set_volume_pricing_attributes
+      options = SolidusVolumePricing::PricingOptions.from_line_item(self)
+      self.money_price = SolidusVolumePricing::Pricer.new(variant).price_for(options)
     end
 
     ::Spree::LineItem.prepend self

--- a/solidus_volume_pricing.gemspec
+++ b/solidus_volume_pricing.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/solidusio-contrib/solidus_volume_pricing"
   spec.metadata["changelog_uri"] = "https://github.com/solidusio-contrib/solidus_volume_pricing/releases"
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.5", "< 4")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0", "< 4")
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/solidus_volume_pricing.gemspec
+++ b/solidus_volume_pricing.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "solidus_backend", [">= 2.4.0", "< 5"]
-  spec.add_dependency "solidus_core", [">= 2.4.0", "< 5"]
+  spec.add_dependency "solidus_backend", [">= 4.0", "< 5"]
+  spec.add_dependency "solidus_core", [">= 4.0", "< 5"]
   spec.add_dependency "solidus_support", "~> 0.8"
   spec.add_dependency "coffee-rails"
   spec.add_dependency "deface"

--- a/solidus_volume_pricing.gemspec
+++ b/solidus_volume_pricing.gemspec
@@ -28,12 +28,12 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "solidus_backend", [">= 2.4.0", "< 5"]
+  spec.add_dependency "solidus_backend", [">= 2.4.0", "< 5"]
+  spec.add_dependency "solidus_core", [">= 2.4.0", "< 5"]
+  spec.add_dependency "solidus_support", "~> 0.8"
   spec.add_dependency "coffee-rails"
   spec.add_dependency "deface"
   spec.add_dependency "sassc-rails"
-  spec.add_dependency "solidus_core", [">= 2.0.0", "< 5"]
-  spec.add_dependency "solidus_support", "~> 0.8"
 
   spec.add_development_dependency "shoulda-matchers"
   spec.add_development_dependency "solidus_dev_support", "~> 2.6"

--- a/solidus_volume_pricing.gemspec
+++ b/solidus_volume_pricing.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "solidus_backend", [">= 4.0", "< 5"]
   spec.add_dependency "solidus_core", [">= 4.0", "< 5"]
-  spec.add_dependency "solidus_support", "~> 0.8"
+  spec.add_dependency "solidus_support", [">= 0.15.0", "< 1"]
   spec.add_dependency "coffee-rails"
   spec.add_dependency "deface"
   spec.add_dependency "sassc-rails"


### PR DESCRIPTION
Solidus 4.6 introduced a change in how the attributes of a line item are set in https://github.com/solidusio/solidus/pull/6313 which makes it impossible to make changes on line item updates with the current patch.

By using our own `before_validation` hook we make sure to still be able to update the line item price after the quantity changed.